### PR TITLE
Update moving average computation to support multiple window sizes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { transformMzcrDataToTimeseries, computeMovingAverageTimeseries } from ".
 
 const mzcrPositivity = mzcrPositivityImport as MzcrCovidTestPositivity[];
 const timeseriesData = transformMzcrDataToTimeseries(mzcrPositivity);
+const enhancedTimeseriesData = computeMovingAverageTimeseries(timeseriesData, [7, 28, 60]);
 
 // Local storage keys
 const TIME_RANGE_KEY = "selectedTimeRange";
@@ -37,7 +38,7 @@ function updateChart(timeRange: string, canvas: HTMLCanvasElement, previousChart
         previousChartInstance.destroy();
     }
 
-    let filteredTimeseriesData = { ...timeseriesData }; // Copy the original data
+    let filteredTimeseriesData = { ...enhancedTimeseriesData }; // Copy the original data
 
     if (timeRange !== "all") {
         const days = parseInt(timeRange);
@@ -52,8 +53,6 @@ function updateChart(timeRange: string, canvas: HTMLCanvasElement, previousChart
         }));
     }
 
-    const movingAverageTimeseries = computeMovingAverageTimeseries(filteredTimeseriesData, [7, 28]);
-
     // Retrieve dataset visibility from local storage
     let datasetVisibility: { [key: string]: boolean } = {};
     try {
@@ -64,8 +63,8 @@ function updateChart(timeRange: string, canvas: HTMLCanvasElement, previousChart
     }
 
     // Prepare data for chart
-    const labels = movingAverageTimeseries.dates;
-    const datasets = movingAverageTimeseries.series.map(series => {
+    const labels = filteredTimeseriesData.dates;
+    const datasets = filteredTimeseriesData.series.map(series => {
         const isVisible = datasetVisibility[series.name] !== undefined ? datasetVisibility[series.name] : true;
         return {
             label: series.name,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import type { MzcrCovidTestPositivity } from "./shared";
 import mzcrPositivityImport from "../data_processed/cr_cov_mzcr/positivity_data.json" with { type: "json" };
 import { Chart, Legend } from 'chart.js/auto';
-import { transformMzcrDataToTimeseries, compute7DayAverageTimeseries } from "./utils";
+import { transformMzcrDataToTimeseries, computeMovingAverageTimeseries } from "./utils";
 
 const mzcrPositivity = mzcrPositivityImport as MzcrCovidTestPositivity[];
 const timeseriesData = transformMzcrDataToTimeseries(mzcrPositivity);
@@ -52,7 +52,7 @@ function updateChart(timeRange: string, canvas: HTMLCanvasElement, previousChart
         }));
     }
 
-    const weeklyAverageTimeseries = compute7DayAverageTimeseries(filteredTimeseriesData);
+    const movingAverageTimeseries = computeMovingAverageTimeseries(filteredTimeseriesData, [7, 28]);
 
     // Retrieve dataset visibility from local storage
     let datasetVisibility: { [key: string]: boolean } = {};
@@ -64,8 +64,8 @@ function updateChart(timeRange: string, canvas: HTMLCanvasElement, previousChart
     }
 
     // Prepare data for chart
-    const labels = weeklyAverageTimeseries.dates;
-    const datasets = weeklyAverageTimeseries.series.map(series => {
+    const labels = movingAverageTimeseries.dates;
+    const datasets = movingAverageTimeseries.series.map(series => {
         const isVisible = datasetVisibility[series.name] !== undefined ? datasetVisibility[series.name] : true;
         return {
             label: series.name,
@@ -90,7 +90,7 @@ function updateChart(timeRange: string, canvas: HTMLCanvasElement, previousChart
             plugins: {
                 title: {
                     display: true,
-                    text: "COVID Test Positivity (MZCR Data) - 7-day Averages"
+                    text: "COVID Test Positivity (MZCR Data) - Moving Averages"
                 },
                 legend: {
                     onClick: (evt, item, legend) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { transformMzcrDataToTimeseries, computeMovingAverageTimeseries } from ".
 
 const mzcrPositivity = mzcrPositivityImport as MzcrCovidTestPositivity[];
 const timeseriesData = transformMzcrDataToTimeseries(mzcrPositivity);
-const enhancedTimeseriesData = computeMovingAverageTimeseries(timeseriesData, [7, 28, 60]);
+const enhancedTimeseriesData = computeMovingAverageTimeseries(timeseriesData, [7, 28]);
 
 // Local storage keys
 const TIME_RANGE_KEY = "selectedTimeRange";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,7 +51,7 @@ export function computeMovingAverageTimeseries(data: TimeseriesData, windowSizes
     });
 
     return {
-        dates: dates,
+        dates: data.dates,
         series: [...data.series, ...averagedSeries],
     };
 }


### PR DESCRIPTION
Update the method to compute moving averages for multiple window sizes.

* Modify `compute7DayAverageTimeseries` in `src/utils.ts` to `computeMovingAverageTimeseries` to accept a list of window sizes and compute moving averages for each specified window size.
* Adjust the algorithm to compute the average using N days prior and assume the same value as the last datapoint if there are no days prior.
* Update `src/main.ts` to import the modified `computeMovingAverageTimeseries` function.
* Modify the `updateChart` function in `src/main.ts` to call `computeMovingAverageTimeseries` with multiple window sizes (7 and 28 days).
* Update the chart rendering logic in `src/main.ts` to handle multiple moving average series.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/petrroll/illdata/pull/2?shareId=4e698a8c-0a13-46cb-b9b4-e547e96a1787).